### PR TITLE
support for multiple services

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ samba_netbios_name: '{{ ansible_hostname }}'
 samba_server_string: '%h file server'
 
 # Name of the /etc/init.d/ service script
-samba_service_name: 'samba'
+samba_service_name: [ 'samba' ]
 
 # Manage iptables modules automatically
 samba_iptables: True

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,15 @@
 ---
 
 - name: Reload samba
-  service: name={{ samba_service_name }} state=reloaded
+  service: name={{ item }} state=reloaded
+  with_items: "{{ samba_service_name }}"
+  register: reloaded
+  ignore_errors: True
+  notify: Restart samba
+
+- name: Restart samba
+  service: name={{ item.item }} state=restarted
+  when: item|failed
+  with_items: reloaded.results
+
 


### PR DESCRIPTION
Hey, I don't really know what I'm doing, but I came up with a solution for issue #2 which seems to work at least on my Debian Jessie machine.

smbd can be reloaded, but nmbd must be restarted. So the updated handler in this PR attempts to reload all services listed in samba_service_name, and then restarts those which failed. 

unfortunately this pr would break existing inventory configurations which specify a single service as a string. I updated defaults/main.yml 

is there any testing or whatever I can do to tidy up this PR ?