### PR TITLE
Remove SO_RCVBUF and SO_SNDBUF from socket_options.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,3 +47,5 @@ Changed
      git ls-files -z | xargs --null -I '{}' find '{}' -type f -print0 | xargs --null sed --in-place --regexp-extended 's/\<(samba)_([^_])/\1__\2/g;'
 
   [ypid_]
+
+- Removed SO_RCVBUF and SO_SNDBUF legacy socket options. [bfabio_]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -153,7 +153,7 @@ samba__default_global:
   hide_files: '/.*/lost+found/'
 
   # Networking / Connections.
-  socket_options: 'TCP_NODELAY SO_RCVBUF=8192 SO_SNDBUF=8192'
+  socket_options: 'TCP_NODELAY'
   deadtime: '10'
   wins_support: 'no'
   dns_proxy: 'no'


### PR DESCRIPTION
"Recent versions of Linux (version 2.6.17 and later) have full
autotuning with 4 MB maximum buffer sizes. Except in some rare cases,
manual tuning is unlikely to substantially improve the performance of
these kernels over most network paths, and is not generally recommended"

(From https://www.psc.edu/index.php/12-about/employment/643-historicaltcptune
§ Tuning TCP for Linux 2.4 and 2.6).